### PR TITLE
Support new ntpdate output format

### DIFF
--- a/ros2_system_monitor/ntp_monitor.py
+++ b/ros2_system_monitor/ntp_monitor.py
@@ -101,9 +101,9 @@ class NtpMonitor(Node):
                     measured_offset = float(
                         re.search("offset (.*),", o).group(1))*1000000
                 else:
-                    # Newer ntpdate versions outputs the following
+                    # Newer ntpdate versions output the following
                     #   YYYY-MM-DD HH:MM:SS.SSSSSS (UTC Offset) OFFSET +/ DELAY HOST IP STRATUM LEAP
-                    # Insted of using regex to get the offset, we can
+                    # Instead of using regex to get the offset, we can
                     # split on spaces and use the fourth value.
                     measured_offset = float(o.split()[3])*1000000
                 st.level = DiagnosticStatus.OK

--- a/ros2_system_monitor/ntp_monitor.py
+++ b/ros2_system_monitor/ntp_monitor.py
@@ -97,8 +97,15 @@ class NtpMonitor(Node):
                 else:
                     raise
             if (res == 0):
-                measured_offset = float(
-                    re.search("offset (.*),", o).group(1))*1000000
+                if "offset" in o:
+                    measured_offset = float(
+                        re.search("offset (.*),", o).group(1))*1000000
+                else:
+                    # Newer ntpdate versions outputs the following
+                    #   YYYY-MM-DD HH:MM:SS.SSSSSS (UTC Offset) OFFSET +/ DELAY HOST IP STRATUM LEAP
+                    # Insted of using regex to get the offset, we can
+                    # split on spaces and use the fourth value.
+                    measured_offset = float(o.split()[3])*1000000
                 st.level = DiagnosticStatus.OK
                 st.message = "OK"
                 st.values = [KeyValue(key="Offset (us)", value=str(measured_offset)),


### PR DESCRIPTION
On Ubuntu 22.04 the output of `ntpdate -q ntp.ubuntu.com` is:

```
server 91.189.91.157, stratum 2, offset -0.054459, delay 0.10048
```

On Ubuntu 24.04 the output of the same command is:

```
2024-05-17 10:56:51.7691 (-0700) -0.066247 +/- 0.081465 ntp.ubuntu.com 185.125.190.58 s2 no-leap
```

This PR supports both versions.